### PR TITLE
Add equilibration_mode parameter for Adaptive

### DIFF
--- a/pele_platform/Checker/valid_flags.py
+++ b/pele_platform/Checker/valid_flags.py
@@ -32,6 +32,7 @@ VALID_FLAGS_PLATFORM = {
     "cluster_conditions": "cluster_conditions",
     "simulation_type": "simulation_type",
     "equilibration": "equilibration",
+    "equilibration_mode": "equilibration_mode",
     "eq_steps": "equilibration_steps",
     "adaptive_restart": "adaptive_restart",
     "input": "global_inputs",

--- a/pele_platform/Templates/template_adaptive.conf
+++ b/pele_platform/Templates/template_adaptive.conf
@@ -41,6 +41,8 @@
 
             "runEquilibration" : $EQUILIBRATION,
 
+            "equilibrationMode": "$EQUILIBRATION_MODE",
+
             "equilibrationLength" : $EQ_STEPS,
 
             "seed": $SEED,

--- a/pele_platform/Utilities/Helpers/simulation.py
+++ b/pele_platform/Utilities/Helpers/simulation.py
@@ -59,7 +59,8 @@ class SimulationBuilder(template_builder.TemplateBuilder):
         # Fill in adaptive template
         self.adaptive_keywords = { "RESTART": env.adaptive_restart, "OUTPUT": env.output, "INPUT":env.adap_ex_input,
                 "CPUS":env.cpus, "PELE_CFILE": os.path.basename(self.pele_file), "LIG_RES": env.residue, "SEED": env.seed, "EQ_STEPS": env.equil_steps,
-                "EQUILIBRATION":env.equilibration, "EPSILON": env.epsilon, "BIAS_COLUMN": env.bias_column, "ITERATIONS": env.iterations, 
+                "EQUILIBRATION":env.equilibration, "EQUILIBRATION_MODE": env.equilibration_mode,"EPSILON": env.epsilon, 
+                "BIAS_COLUMN": env.bias_column, "ITERATIONS": env.iterations, 
                 "PELE_STEPS": env.pele_steps, "REPORT_NAME": env.report_name, "SPAWNING_TYPE": env.spawning, "DENSITY": env.density,
                 "SIMULATION_TYPE": env.simulation_type, "CLUSTER_VALUES": env.cluster_values, "CLUSTER_CONDITION": env.cluster_conditions,
                 "UNBINDING": env.unbinding_block, "USESRUN": env.usesrun, "LIGAND": env.ligand,

--- a/pele_platform/Utilities/Helpers/yaml_parser.py
+++ b/pele_platform/Utilities/Helpers/yaml_parser.py
@@ -115,6 +115,7 @@ class YamlParser(object):
         self.cluster_conditions = data.get(valid_flags["cluster_conditions"], None)
         self.simulation_type = data.get(valid_flags["simulation_type"], None)
         self.equilibration = data.get(valid_flags["equilibration"], None)
+        self.equilibration_mode = data.get(valid_flags["equilibration_mode"], None)
         self.clust_type = data.get(valid_flags["clust_type"], None)
         self.eq_steps = data.get(valid_flags["eq_steps"], None)
         self.adaptive_restart = data.get(valid_flags["adaptive_restart"], None)

--- a/pele_platform/Utilities/Parameters/SimulationParams/simulation_params.py
+++ b/pele_platform/Utilities/Parameters/SimulationParams/simulation_params.py
@@ -314,6 +314,11 @@ class SimulationParams(
             if args.equilibration
             else self.simulation_params.get("equilibration", "false")
         )
+        self.equilibration_mode = (
+                args.equilibration_mode 
+                if args.equilibration_mode
+                else self.simulation_params.get("equilibration_mode", "equilibrationSelect")
+        )
         self.adaptive_restart = args.adaptive_restart
         self.poses = (
             args.poses


### PR DESCRIPTION
Adds the equilibration_mode parameter to control the type of equilibration to run when running Adaptive from the platform. The different modes are described in the [Adaptive documentation](https://adaptivepele.github.io/AdaptivePELE/UserManual.html#simulation-block) (_equilibrationMode_ parameter)