### PR TITLE
Preventing PPP from running twice

### DIFF
--- a/devtools/conda_envs/standard.yaml
+++ b/devtools/conda_envs/standard.yaml
@@ -1,0 +1,10 @@
+name: peleplatform
+
+channels:
+  - nostrumbiodiscovery
+  - martimunicoy
+  - conda-forge
+
+dependencies:
+  - pele_platform
+

--- a/devtools/conda_envs/test_env.yaml
+++ b/devtools/conda_envs/test_env.yaml
@@ -1,0 +1,30 @@
+name: peleplatform_env
+
+channels:
+  - nostrumbiodiscovery
+  - martimunicoy
+  - conda-forge
+
+dependencies:
+  - python
+  - numpy
+  - matplotlib
+  - seaborn
+  - scipy
+  - biopython
+  - cython
+  - pytest
+  - pyyaml
+  - pillow
+  - fpdf
+  - rdkit
+  - adaptive_pele==1.7.1
+  - ploprottemp==1.0.1
+  - scikit-learn>0.20
+  - pandas==1.2.3
+  - frag_pele==3.0.0
+  - pppele==1.0.8
+  - peleffy==1.3.2
+  - hdbscan==0.8.27
+  - mdtraj==1.9.5
+

--- a/devtools/conda_recipe/meta.yaml
+++ b/devtools/conda_recipe/meta.yaml
@@ -40,7 +40,7 @@ requirements:
     - scikit-learn>0.20
     - rdkit
     - frag_pele==3.0.0
-    - pppele==1.0.7
+    - pppele==1.0.8
     - peleffy==1.3.2
     #- drug_learning not ready yet
     - hdbscan==0.8.27

--- a/pele_platform/Adaptive/simulation.py
+++ b/pele_platform/Adaptive/simulation.py
@@ -129,21 +129,25 @@ def run_adaptive(args):
                 parameters.residue,
                 output_folder=parameters.inputs_dir)
 
-            inputs = [os.path.join(parameters.inputs_dir, inp)
-                      for inp in inputs]
+            parameters.input = [os.path.join(parameters.inputs_dir, inp)
+                                for inp in inputs]
 
             parameters.adap_ex_input = ", ".join(
-                ['"' + input + '"' for input in inputs]
+                ['"' + input + '"' for input in parameters.input]
             ).strip('"')
             hp.silentremove(ligand_positions)
 
         # Prepare System
-        if parameters.no_ppp or parameters.input:  # No need to run system through PPP, if we already preprocessed parameters.input
+        if parameters.no_ppp or parameters.input:  # No need to run system through PPP, if we already preprocessed
+            # parameters.input
             missing_residues = []
             if parameters.input:
                 # If we have more than one input
                 for input in parameters.input:
-                    shutil.copy(input, parameters.inputs_dir)
+                    try:
+                        shutil.copy(input, parameters.inputs_dir)
+                    except shutil.SameFileError:  # systems that go through randomization are already moved
+                        pass
             else:
                 shutil.copy(parameters.system, parameters.inputs_dir)
         else:

--- a/pele_platform/Utilities/Helpers/helpers.py
+++ b/pele_platform/Utilities/Helpers/helpers.py
@@ -313,7 +313,7 @@ def find_nonstd_residue(pdb):
                     line[17:20]
                     for line in f
                     if line.startswith("ATOM")
-                    and line[17:20] not in gv.supported_aminoacids
+                    and line[17:20] not in gv.default_supported_aminoacids
                 ]
             )
         )

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,6 @@ peleffy==1.3.2
 hdbscan==0.8.27
 AdaptivePELE==1.7.1
 frag_pele==3.0.0
-PPPele==1.0.7
+PPPele==1.0.8
 PlopRotTemp==1.0.1
 seaborn

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
         "hdbscan==0.8.27",
         "AdaptivePELE==1.7.1",
         "frag_pele==3.0.0",
-        "PPPele==1.0.7",
+        "PPPele==1.0.8",
         "PlopRotTemp==1.0.1",
         "seaborn"
     ],

--- a/tests/test_adaptive.py
+++ b/tests/test_adaptive.py
@@ -326,9 +326,7 @@ def test_gpcr(args=GPCR_ARGS):
     job = main.run_platform_from_yaml(args)
     errors = check_file(job.pele_dir, "pele.conf", GPCR_VALUES, errors)
     input_file = os.path.join(job.inputs_dir, "complex_processed.pdb")
-    if not os.path.exists(input_file):
-        errors.append("skip_ppp")
-    assert not errors
+    assert not os.path.exists(input_file)
 
 
 def check_file_regex(directory, file, patterns, errors):


### PR DESCRIPTION
Some tests involving randomization were failing on the first try because:
- PPP was called twice - first on system, then in created inputs (fixed in this PR)
- supported_aminoacids in PPP were modified and carried over to the next test in the session (fixed in [PPP](https://github.com/nostrumbiodiscovery/PPP/pull/6)).

All tests pass using beta7 environment and devel version of PPP.