### PR TITLE
PELE-510 Checker for flag incompatibilities and version header

### DIFF
--- a/pele_platform/Adaptive/simulation.py
+++ b/pele_platform/Adaptive/simulation.py
@@ -25,6 +25,7 @@ import pele_platform.Adaptive.pca as pca
 import pele_platform.Adaptive.plop_solvent as sv
 import pele_platform.Adaptive.plop_ligand_parametrization as lg
 from pele_platform.Utilities.Helpers import ligand_conformations
+from pele_platform.Checker import pdb_checker
 
 
 def run_adaptive(args):
@@ -51,6 +52,8 @@ def run_adaptive(args):
         parameters.logger.info(
             "System: {}; Platform Functionality: {}\n\n".format(
                 parameters.residue, parameters.software))
+
+        pdb_checker.PDBChecker(parameters.system).check_negative_residues()
 
         # Create inputs directory
         if not os.path.exists(parameters.inputs_dir):

--- a/pele_platform/Errors/custom_errors.py
+++ b/pele_platform/Errors/custom_errors.py
@@ -100,3 +100,7 @@ class PELENotFound(Exception):
 
 class IncorrectResidueNumbers(Exception):
     pass
+
+
+class IncompatibleYamlFlags(Exception):
+    pass

--- a/pele_platform/Examples/checker/incompatible_flags.yaml
+++ b/pele_platform/Examples/checker/incompatible_flags.yaml
@@ -1,0 +1,7 @@
+system: '../pele_platform/Examples/checker/complex2.pdb'
+chain: 'Z'
+resname: 'API'
+templates:
+  - '../apiz'
+  - '../xxxz'
+mae_lig: '../api.mae'

--- a/pele_platform/Utilities/Helpers/launcher.py
+++ b/pele_platform/Utilities/Helpers/launcher.py
@@ -8,8 +8,10 @@ import pele_platform.out_in.main as outin
 from pele_platform.PPI.main import run_ppi
 from pele_platform.enzyme_engineering.saturated_mutagenesis import SaturatedMutagenesis
 from pele_platform.covalent_docking.main import CovalentDocking
+from pele_platform.constants import constants
 import pele_platform.Utilities.Parameters.parameters as pv
 import argparse
+import pkg_resources
 
 
 @dataclass
@@ -29,6 +31,7 @@ class Launcher:
     def launch(self) -> pv.ParametersBuilder:
         # Launch package from input.yaml
         self._define_package_to_run()
+        print(constants.version_header.format(pkg_resources.get_distribution("pele_platform").version))
         job_variables = self.launch_package(self._args.package, no_check=self._args.no_check)
         return job_variables
 

--- a/pele_platform/Utilities/Parameters/SimulationParams/simulation_params.py
+++ b/pele_platform/Utilities/Parameters/SimulationParams/simulation_params.py
@@ -16,7 +16,6 @@ from pele_platform.Utilities.Parameters.SimulationParams.site_finder import site
 from pele_platform.Utilities.Parameters.SimulationParams.PPI import ppi
 import pele_platform.Utilities.Helpers.helpers as hp
 
-
 LOGFILE = '"simulationLogPath" : "$OUTPUT_PATH/logFile.txt",'
 
 
@@ -45,6 +44,7 @@ class SimulationParams(
         self.constraints_params(args)
         self.interaction_restrictions_params(args)
         self.covalent_docking_params(args)
+        self.check_flags(args)
 
         # Create all simulation types (could be more efficient --> chnage in future)
         super().generate_msm_params(args)
@@ -643,12 +643,14 @@ class SimulationParams(
         """
         self.covalent_residue = args.covalent_residue if args.covalent_residue else None
         self.nonbonding_radius = args.nonbonding_radius if args.nonbonding_radius is not None else 20.0
-        self.perturbation_trials = args.perturbation_trials if args.perturbation_trials is not None else self.simulation_params.get("perturbation_trials", 10)
+        self.perturbation_trials = args.perturbation_trials if args.perturbation_trials is not None else self.simulation_params.get(
+            "perturbation_trials", 10)
         self.max_trials_for_one = self.perturbation_trials * 2
 
         if self.covalent_residue:
             # Refinement distance should be empty for the general simulation (handled in CovalentDocking runner).
-            self.refinement_angle = args.refinement_angle if args.refinement_angle is not None else self.simulation_params.get("refinement_angle", 10)
+            self.refinement_angle = args.refinement_angle if args.refinement_angle is not None else self.simulation_params.get(
+                "refinement_angle", 10)
             self.refinement_angle = cs.refinement_angle.format(self.refinement_angle)
             self.sidechain_perturbation = cs.SIDECHAIN_PERTURBATION
             self.covalent_sasa = cs.SASA_COVALENT.format(self.covalent_residue)
@@ -657,3 +659,21 @@ class SimulationParams(
             self.sidechain_perturbation = ""
             self.covalent_sasa = ""
             self.refinement_angle = ""
+
+    @staticmethod
+    def check_flags(args):
+        """
+        Recognises any flags incompatible with each other.
+        """
+        if args.mae_lig and args.template:
+            mae_lig_residue = os.path.basename(os.path.splitext(args.mae_lig)[0]).upper()
+
+            if isinstance(args.template, str):
+                args.template = [args.template]
+
+            template_residues = [os.path.basename(os.path.splitext(file)[0]).upper().rstrip("Z")
+                                 for file in args.template]
+
+            if mae_lig_residue in template_residues:
+                raise custom_errors.IncompatibleYamlFlags(
+                    "Argument mae_lig cannot be used in conjunction with ligand template,")

--- a/pele_platform/constants/constants.py
+++ b/pele_platform/constants/constants.py
@@ -499,9 +499,7 @@ CONFORMATION_FREQUENCY = '"conformationPerturbationFrequency": {},'
 
 version_header = """
 PELE Platform {}
----------------------------
+--------------------------
 Nostrum Biodiscovery SL
-www.nostrumbiodiscovery.com
-
 All rights reserved, 2021.
 """

--- a/pele_platform/constants/constants.py
+++ b/pele_platform/constants/constants.py
@@ -496,3 +496,12 @@ in_pele_data = ["caz", "clz", "cuiz", "cuz", "hohz", "mgz", "mnz", "naz", "spcz"
 refinement_angle = '"refinementAngle": {},'
 
 CONFORMATION_FREQUENCY = '"conformationPerturbationFrequency": {},'
+
+version_header = """
+PELE Platform {}
+---------------------------
+Nostrum Biodiscovery SL
+www.nostrumbiodiscovery.com
+
+All rights reserved, 2021.
+"""

--- a/tests/test_others.py
+++ b/tests/test_others.py
@@ -415,3 +415,14 @@ def test_latest_pele_dir(dir_index, pele_dir):
     # Clean up
     for i in range(dir_index + 1):
         shutil.rmtree(f"XXX_Pele_{i}")
+
+
+def test_flag_compatibility_checker():
+    """
+    Checks if the platform raises an error when incompatible flags are introduced.
+    """
+
+    yaml = os.path.join(test_path, "checker", "incompatible_flags.yaml")
+
+    with pytest.raises(ce.IncompatibleYamlFlags):
+        main.run_platform_from_yaml(yaml)


### PR DESCRIPTION
Checker to ensure users do not set `mae_lig` and `templates` flag for the ligand.
Added version header printed at runtime.