### PR TITLE
PELE-550 Swapped warning for exception to prevent silent peleffy fails

### DIFF
--- a/docs/build_docs/source/flags/all_packages/index.rst
+++ b/docs/build_docs/source/flags/all_packages/index.rst
@@ -284,6 +284,8 @@ Alternatively, as before, you can provide your own template and/or rotamer files
 
     - **solvent_template**: External file with solvent parameters in JSON format.
 
+    - **skip_ligand_prep**: List of residue names that should not be parametrized automatically.
+
 ..  code-block:: yaml
 
   templates:
@@ -294,6 +296,9 @@ Alternatively, as before, you can provide your own template and/or rotamer files
     - "/home/simulation_files/LIG.rot.assign"
   solvent_template:
     - "/home/simulation_files/ligandParams.txt"
+  skip_ligand_prep:
+    - "LIG"
+    - "MG"
 
 
 Ligand conformations

--- a/pele_platform/Adaptive/parametrizer.py
+++ b/pele_platform/Adaptive/parametrizer.py
@@ -575,7 +575,7 @@ class Parametrizer:
 
                     print(f"Parametrized {molecule.tag.strip()}.")
                 except AssertionError as e:
-                    warnings.warn(
+                    raise custom_errors.LigandPreparationError(
                         f"Failed to parametrize residue {molecule.tag.strip()}. You can skip it or "
                         f"parametrize manually (see documentation: "
                         f"https://nostrumbiodiscovery.github.io/pele_platform/errors/index.html#parametrization"


### PR DESCRIPTION
It halts the execution whenever the ligand is not right (e.g. missing hydrogens).
Prints the peleffy assertion error to help with debugging.
All parametrization tests still pass.